### PR TITLE
Merge Optimizations/memandgc2 branch from Nostek fork

### DIFF
--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -36,8 +36,8 @@ namespace XNode {
 
             Dictionary<string, NodePort> staticPorts;
             if (!portDataCache.TryGetValue(nodeType, out staticPorts)) {
-                 staticPorts = new Dictionary<string, NodePort>();
-            }            
+                staticPorts = new Dictionary<string, NodePort>();
+            }
 
             // Cleanup port dict - Remove nonexisting static ports - update static port types
             // AND update dynamic ports (albeit only those in lists) too, in order to enforce proper serialisation.
@@ -69,6 +69,7 @@ namespace XNode {
                     dynamicListPorts.Add(port);
                 }
             }
+
             // Add missing ports
             foreach (NodePort staticPort in staticPorts.Values) {
                 if (!ports.ContainsKey(staticPort.fieldName)) {
@@ -206,8 +207,8 @@ namespace XNode {
                 if (inputAttrib != null && outputAttrib != null) Debug.LogError("Field " + fieldInfo[i].Name + " of type " + nodeType.FullName + " cannot be both input and output.");
                 else {
                     if (!portDataCache.ContainsKey(nodeType)) portDataCache.Add(nodeType, new Dictionary<string, NodePort>());
-                     NodePort port = new NodePort(fieldInfo[i]);
-                     portDataCache[nodeType].Add(port.fieldName, port);
+                    NodePort port = new NodePort(fieldInfo[i]);
+                    portDataCache[nodeType].Add(port.fieldName, port);
                 }
 
                 if (formerlySerializedAsAttribute != null) {

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -9,6 +9,7 @@ namespace XNode {
         private static PortDataCache portDataCache;
         private static Dictionary<System.Type, Dictionary<string, string>> formerlySerializedAsCache;
         private static Dictionary<System.Type, string> typeQualifiedNameCache;
+        private static List<NodePort> dynamicListPorts;
         private static bool Initialized { get { return portDataCache != null; } }
 
         public static string GetTypeQualifiedName(System.Type type) {
@@ -32,7 +33,6 @@ namespace XNode {
             Dictionary<string, string> formerlySerializedAs = null;
             if (formerlySerializedAsCache != null) formerlySerializedAsCache.TryGetValue(nodeType, out formerlySerializedAs);
 
-            List<NodePort> dynamicListPorts = new List<NodePort>();
 
             Dictionary<string, NodePort> staticPorts;
             if (!portDataCache.TryGetValue(nodeType, out staticPorts)) {
@@ -103,6 +103,8 @@ namespace XNode {
                 listPort.connectionType = backingPort.connectionType;
                 listPort.typeConstraint = backingPort.typeConstraint;
             }
+
+            dynamicListPorts.Clear();
         }
 
         /// <summary>
@@ -144,6 +146,7 @@ namespace XNode {
         /// <summary> Cache node types </summary>
         private static void BuildCache() {
             portDataCache = new PortDataCache();
+            dynamicListPorts = new List<NodePort>();
             System.Type baseType = typeof(Node);
             List<System.Type> nodeTypes = new List<System.Type>();
             System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -220,7 +220,6 @@ namespace XNode {
             }
         }
 
-        [System.Serializable]
         private class PortDataCache : Dictionary<System.Type, Dictionary<string, NodePort>> { }
     }
 }

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -125,10 +125,11 @@ namespace XNode {
             // Ports flagged as "dynamicPortList = true" end up having a "backing port" and a name with an index, but we have
             // no guarantee that a dynamic port called "output 0" is an element in a list backed by a static "output" port.
             // Thus, we need to check for attributes... (but at least we don't need to look at all fields this time)
-            string[] fieldNameParts = port.fieldName.Split(' ');
-            if (fieldNameParts.Length != 2) return false;
+            int fieldNameSpaceIndex = port.fieldName.IndexOf(' ');
+            if (fieldNameSpaceIndex < 0) return false;
+            string fieldNamePart = port.fieldName.Substring(0, fieldNameSpaceIndex);
 
-            FieldInfo backingPortInfo = port.node.GetType().GetField(fieldNameParts[0]);
+            FieldInfo backingPortInfo = port.node.GetType().GetField(fieldNamePart);
             if (backingPortInfo == null) return false;
 
             object[] attribs = backingPortInfo.GetCustomAttributes(true);

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -153,6 +153,10 @@ namespace XNode {
         private static void BuildCache() {
             portDataCache = new PortDataCache();
             dynamicListPorts = new List<NodePort>();
+
+#if UNITY_2019_2_OR_NEWER && UNITY_EDITOR
+            List<System.Type> nodeTypes = UnityEditor.TypeCache.GetTypesDerivedFrom<Node>().Where(type => !type.IsAbstract).ToList();
+#else
             System.Type baseType = typeof(Node);
             List<System.Type> nodeTypes = new List<System.Type>();
             System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
@@ -177,6 +181,7 @@ namespace XNode {
                         break;
                 }
             }
+#endif
 
             for (int i = 0; i < nodeTypes.Count; i++) {
                 CachePorts(nodeTypes[i]);


### PR DESCRIPTION
Origin PR: https://github.com/Siccity/xNode/pull/360/files
> the removedPorts change, I'm actually not sure it makes a difference as c# documentation says allocation doesn't happen until the first Add.
UnityEditor.TypeCache.GetTypesDerivedFrom() is Editor only, but speeds up reload time.
The remove of [serialized] is something I missed from the last PR.